### PR TITLE
Ci pytest fix

### DIFF
--- a/.github/workflows/python-ci-conda.yml
+++ b/.github/workflows/python-ci-conda.yml
@@ -20,7 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda env update --file environment.yml --name dab
+        conda env update --file environment.yml --name base
     - name: Lint with flake8
       run: |
         conda install flake8


### PR DESCRIPTION
- Fixed module not found by going from pytest to python -m pytest
- Fixed conda environment install, now installing to base env for CI so it doesn't have to activate a separate environment