### PR TITLE
Updated Lyapunov Exponent calculation defaults

### DIFF
--- a/dabench/data/data.py
+++ b/dabench/data/data.py
@@ -193,7 +193,7 @@ class Data():
         return dxaux
 
     def calc_lyapunov_exponents_series(self, total_time=None, rescale_time=1,
-                                       convergence=0.05, x0=None):
+                                       convergence=0.01, x0=None):
         """Computes the spectrum of Lyapunov Exponents.
 
         Notes:
@@ -202,7 +202,7 @@ class Data():
             converges. There are three ways to make the estimate more accurate:
                 1. Decrease the delta_t of the model
                 2. Increase total_time
-                3. Decrease rescale time
+                3. Decrease rescale time (try increasing total_time first)
             Algorithm: Eckmann 85,
             https://www.ihes.fr/~ruelle/PUBLICATIONS/%5B81%5D.pdf pg 651
             This method computes the full time series of Lyapunov Exponents,
@@ -213,10 +213,10 @@ class Data():
             total_time (float) : Time to integrate over to compute LEs.
                 Usually there's a tradeoff between accuracy and computation
                 time (more total_time leads to higher accuracy but more
-                computation time). Default depends on model type and matches
-                the spinup used to generate the default initial conditions:
-                For Lorenz63: n_steps=6000 (total_time=60 for delta_t=0.01)
-                For Lorenz96: n_steps=14400 (total_time=144 for delta_t=0.01)
+                computation time). Default depends on model type and are based
+                roughly on how long it takes for satisfactory convergence:
+                For Lorenz63: n_steps=15000 (total_time=150 for delta_t=0.01)
+                For Lorenz96: n_steps=50000 (total_time=500 for delta_t=0.01)
             rescale_time (float) : Time for when the algorithm rescales the
                 propagator to reduce the exponential growth in errors.
                 Default is 1 (i.e. 100 timesteps when delta_t = 0.01).
@@ -236,9 +236,9 @@ class Data():
         if total_time is None:
             subclass_name = self.__class__.__name__
             if subclass_name == 'DataLorenz63':
-                total_time = int(6000*self.delta_t)
+                total_time = int(15000*self.delta_t)
             elif subclass_name == 'DataLorenz96':
-                total_time = int(14400*self.delta_t)
+                total_time = int(50000*self.delta_t)
             else:
                 total_time = 100
 
@@ -292,10 +292,10 @@ class Data():
             total_time (float) : Time to integrate over to compute LEs.
                 Usually there's a tradeoff between accuracy and computation
                 time (more total_time leads to higher accuracy but more
-                computation time). Default depends on model type and matches
-                the spinup used to generate the default initial conditions:
-                For Lorenz63: n_steps=6000 (total_time=60 for delta_t=0.01)
-                For Lorenz96: n_stpes=14400 (total_time=144 for delta_t=0.01)
+                computation time). Default depends on model type and are based
+                roughly on how long it takes for satisfactory convergence:
+                For Lorenz63: n_steps=15000 (total_time=150 for delta_t=0.01)
+                For Lorenz96: n_steps=50000 (total_time=500 for delta_t=0.01)
             rescale_time (float) : Time for when the algorithm rescales the
                 propagator to reduce the exponential growth in errors.
                 Default is 1 (i.e. 100 timesteps when delta_t = 0.01).

--- a/tests/lorenz63_class_test.py
+++ b/tests/lorenz63_class_test.py
@@ -92,7 +92,7 @@ def test_lyapunov_exponents(lorenz, lorenz_lyaps):
 def test_lyapunov_exponents_series(lorenz, lorenz_lyaps):
     """Tests shape of lyapunov exponents series and value of last timestep"""
     LE = lorenz.calc_lyapunov_exponents_final()
-    assert lorenz_lyaps.shape == (int(60/1) - 1, lorenz.system_dim)
+    assert lorenz_lyaps.shape == (150 - 1, lorenz.system_dim)
     assert jnp.all(LE == lorenz_lyaps[-1])
 
 
@@ -104,5 +104,5 @@ def test_lyapunov_exponents_values(lorenz_lyaps):
     """
     LE = lorenz_lyaps[-1]
     known_LE = jnp.array([0.906, 0, -14.572])
-    assert jnp.allclose(known_LE, LE,  rtol=0.1, atol=0.01)
+    assert jnp.allclose(known_LE, LE,  rtol=0.05, atol=0.01)
 

--- a/tests/lorenz96_class_test.py
+++ b/tests/lorenz96_class_test.py
@@ -1,6 +1,5 @@
 """Tests for DataLorenz96 class (dabench.data.lorenz96.DataLorenz96)"""
 
-from dabench.data import data
 from dabench.data.lorenz96 import DataLorenz96
 import jax.numpy as jnp
 import pytest
@@ -151,12 +150,12 @@ def test_lyapunov_exponents(lorenz96, lorenz96_lyaps):
 def test_lyapunov_exponents_series(lorenz96, lorenz96_lyaps):
     """Tests shape of lyapunov exponents series and value of last timestep"""
     LE = lorenz96.calc_lyapunov_exponents_final()
-    assert lorenz96_lyaps.shape == (int(144/1) - 1, lorenz96.system_dim)
+    assert lorenz96_lyaps.shape == (500 - 1, lorenz96.system_dim)
     assert jnp.all(LE == lorenz96_lyaps[-1])
 
 
 def test_lyapunov_exponents_values(lorenz96_lyaps):
     """Tests that Lorenz96 lyapunov exponents are close to known values."""
     LE = lorenz96_lyaps[-1]
-    known_LE = jnp.array([0.3559, -0.0096, -0.4594, -1.3361, -3.5008])
-    assert jnp.allclose(known_LE, LE,  rtol=0.1, atol=0.01)
+    known_LE = jnp.array([0.4717, -0.0022, -0.4617, -1.3783, -3.5838])
+    assert jnp.allclose(known_LE, LE,  rtol=0.05, atol=0.01)


### PR DESCRIPTION
- Updated defaults for the Lyap Exp calculations to match spinup that we used to calculate initial conditions. Set rescale_time to 1 by default, or 100 timesteps for delta_t=0.01
- Tested L63 values against known values from here: https://sprott.physics.wisc.edu/chaos/lorenzle.htm. Close, but not exact (all within 5%)
- Tested L96 values by recreating and comparing to this plot: https://www.researchgate.net/figure/Time-evolution-of-Lyapunov-exponents-for-the-Lorenz-96-system_fig1_353068684. They look good based on an eye test.