### PR TITLE
RC Model fixes (and some DA fixes)

### DIFF
--- a/dabench/dacycler/_etkf.py
+++ b/dabench/dacycler/_etkf.py
@@ -210,4 +210,4 @@ class ETKF(dacycler.DACycler):
                                     R=R,
                                     rho=self.multiplicative_inflation)
 
-        return Xb_ds.assign(x=(['ensemble','i'], Xa.T))
+        return Xb_ds.assign({list(Xb_ds.data_vars)[0]:(Xb_ds.dims, Xa.T)})

--- a/dabench/dacycler/_var3d.py
+++ b/dabench/dacycler/_var3d.py
@@ -103,4 +103,4 @@ class Var3D(dacycler.DACycler):
         xa, ierr = jscipy.sparse.linalg.cg(A, b1, x0=xb, tol=1e-05,
                                            maxiter=1000)
 
-        return xb_ds.assign(x=(xb_ds.dims, xa.T))
+        return xb_ds.assign({list(xb_ds.data_vars)[0]:(xb_ds.dims, xa.T)})

--- a/dabench/data/_xarray_accessor.py
+++ b/dabench/data/_xarray_accessor.py
@@ -48,6 +48,7 @@ class DABenchDatasetAccessor:
         for sl in split_lengths:
             end_i = start_i + sl
             out_ds.append(self._obj.isel(time=slice(start_i, end_i)))
+            start_i = end_i
         return tuple(out_ds)
 
 


### PR DESCRIPTION
Solves #51 

- Removed predict() method from reservoir computing model to avoid confusion with forecast()
- Renamed generate() to readin() to avoid confusion with data generators. This method applies Win to an input signal time series to produce reservoir state time series. Open to other names, let me know what you think.
- Related to rc model DA, updated ETKF and Var3D da cyclers to match input xarray variable names when producing analysis. Previously they always returned an xarray dataset with a data variable "x", but for the rc model the data_variable is named "r". Currently, there is no way of producing an analysis with multiple variable names (e.g. "wind" and "pressure"). These variables would have to be flattened into a single state vector before running DA. If this is a problem, we should add a github issue to this effect.

